### PR TITLE
Exclude config.ts from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,7 +19,7 @@ sonar.language=js
 
 sonar.profile=node
 
-sonar.exclusions=**/*.test.tsx, **/*.test.ts, **/*.test.js, **/*.test.jsx, **/*.stories.tsx, **/*/Icon/config.ts
+sonar.exclusions=**/*.test.tsx, **/*.test.ts, **/*.test.js, **/*.test.jsx, **/*.stories.tsx, **/*config.ts
 
 #sonar.javascript.jstest.reportsPath=reports
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
About this pr

Sonarqube does not recognize an exclusion pattern which contains partial path and the file name to exclude. It requires to ignore the partial path while extending an exclusion.